### PR TITLE
Feature implementation from commits ada1b4b..4012901

### DIFF
--- a/karate-core/src/main/java/com/intuit/karate/Logger.java
+++ b/karate-core/src/main/java/com/intuit/karate/Logger.java
@@ -48,6 +48,8 @@ public class Logger {
 
     private boolean appendOnly;
 
+    private boolean logOnly;
+
     public void setAppender(LogAppender appender) {
         this.appender = appender;
     }
@@ -68,6 +70,14 @@ public class Logger {
         return appendOnly;
     }
 
+    public void setLogOnly(boolean logOnly) {
+        this.logOnly = logOnly;
+    }
+
+    public boolean isLogOnly() {
+        return logOnly;
+    }
+
     public Logger(Class clazz) {
         LOGGER = LoggerFactory.getLogger(clazz);
     }
@@ -85,7 +95,9 @@ public class Logger {
             if (!appendOnly) {
                 LOGGER.trace(format, arguments);
             }
-            formatAndAppend(format, arguments);
+            if (!logOnly) {
+                formatAndAppend(format, arguments);
+            }
         }
     }
 
@@ -94,7 +106,9 @@ public class Logger {
             if (!appendOnly) {
                 LOGGER.debug(format, arguments);
             }
-            formatAndAppend(format, arguments);
+            if (!logOnly) {
+                formatAndAppend(format, arguments);
+            }
         }
     }
 
@@ -103,7 +117,9 @@ public class Logger {
             if (!appendOnly) {
                 LOGGER.info(format, arguments);
             }
-            formatAndAppend(format, arguments);
+            if (!logOnly) {
+                formatAndAppend(format, arguments);
+            }
         }
     }
 
@@ -112,7 +128,9 @@ public class Logger {
             if (!appendOnly) {
                 LOGGER.warn(format, arguments);
             }
-            formatAndAppend(format, arguments);
+            if (!logOnly) {
+                formatAndAppend(format, arguments);
+            }
         }
     }
 
@@ -121,7 +139,9 @@ public class Logger {
             if (!appendOnly) {
                 LOGGER.error(format, arguments);
             }
-            formatAndAppend(format, arguments);
+            if (!logOnly) {
+                formatAndAppend(format, arguments);
+            }
         }
     }
 

--- a/karate-core/src/main/java/com/intuit/karate/Main.java
+++ b/karate-core/src/main/java/com/intuit/karate/Main.java
@@ -390,6 +390,7 @@ public class Main implements Callable<Void> {
                 return context;
             });
             HttpServer.Builder builder = HttpServer.config(config)
+                    .local(false)
                     .corsEnabled(true);
             if (ssl) {
                 builder.https(port);

--- a/karate-core/src/main/java/com/intuit/karate/Runner.java
+++ b/karate-core/src/main/java/com/intuit/karate/Runner.java
@@ -34,10 +34,11 @@ import com.intuit.karate.driver.DriverRunner;
 import com.intuit.karate.http.HttpClientFactory;
 import com.intuit.karate.report.SuiteReports;
 import com.intuit.karate.resource.ResourceUtils;
+import org.slf4j.LoggerFactory;
+
 import java.io.File;
 import java.util.*;
 import java.util.stream.Collectors;
-import org.slf4j.LoggerFactory;
 
 /**
  *
@@ -112,6 +113,7 @@ public class Runner {
         boolean outputCucumberJson;
         boolean dryRun;
         boolean debugMode;
+        boolean ignoreJunitNoScenariosAssertion;
         Map<String, String> systemProperties;
         Map<String, Object> callSingleCache;
         Map<String, ScenarioCall.Result> callOnceCache;
@@ -145,6 +147,7 @@ public class Runner {
             b.outputCucumberJson = outputCucumberJson;
             b.dryRun = dryRun;
             b.debugMode = debugMode;
+            b.ignoreJunitNoScenariosAssertion = ignoreJunitNoScenariosAssertion;
             b.systemProperties = systemProperties;
             b.callSingleCache = callSingleCache;
             b.callOnceCache = callOnceCache;
@@ -436,7 +439,10 @@ public class Runner {
             debugMode = value;
             return (T) this;
         }
-
+        public T ignoreJunitNoScenariosAssertion(boolean value) {
+            ignoreJunitNoScenariosAssertion = value;
+            return (T) this;
+        }
         public T callSingleCache(Map<String, Object> value) {
             callSingleCache = value;
             return (T) this;

--- a/karate-core/src/main/java/com/intuit/karate/Runner.java
+++ b/karate-core/src/main/java/com/intuit/karate/Runner.java
@@ -113,7 +113,7 @@ public class Runner {
         boolean outputCucumberJson;
         boolean dryRun;
         boolean debugMode;
-        boolean ignoreJunitNoScenariosAssertion;
+        boolean failWhenNoScenariosFound;
         Map<String, String> systemProperties;
         Map<String, Object> callSingleCache;
         Map<String, ScenarioCall.Result> callOnceCache;
@@ -147,7 +147,7 @@ public class Runner {
             b.outputCucumberJson = outputCucumberJson;
             b.dryRun = dryRun;
             b.debugMode = debugMode;
-            b.ignoreJunitNoScenariosAssertion = ignoreJunitNoScenariosAssertion;
+            b.failWhenNoScenariosFound = failWhenNoScenariosFound;
             b.systemProperties = systemProperties;
             b.callSingleCache = callSingleCache;
             b.callOnceCache = callOnceCache;
@@ -439,10 +439,12 @@ public class Runner {
             debugMode = value;
             return (T) this;
         }
-        public T ignoreJunitNoScenariosAssertion(boolean value) {
-            ignoreJunitNoScenariosAssertion = value;
+        
+        public T failWhenNoScenariosFound(boolean value) {
+            failWhenNoScenariosFound = value;
             return (T) this;
         }
+
         public T callSingleCache(Map<String, Object> value) {
             callSingleCache = value;
             return (T) this;

--- a/karate-core/src/main/java/com/intuit/karate/Suite.java
+++ b/karate-core/src/main/java/com/intuit/karate/Suite.java
@@ -28,8 +28,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.intuit.karate.core.FeatureCall;
 import com.intuit.karate.core.FeatureResult;
 import com.intuit.karate.core.FeatureRuntime;
-import com.intuit.karate.driver.DriverRunner;
-import com.intuit.karate.report.ReportUtils;
 import com.intuit.karate.core.Scenario;
 import com.intuit.karate.core.ScenarioCall;
 import com.intuit.karate.core.ScenarioResult;
@@ -37,27 +35,23 @@ import com.intuit.karate.core.ScenarioRuntime;
 import com.intuit.karate.core.Step;
 import com.intuit.karate.core.SyncExecutorService;
 import com.intuit.karate.core.Tags;
+import com.intuit.karate.driver.DriverRunner;
 import com.intuit.karate.http.HttpClientFactory;
+import com.intuit.karate.report.ReportUtils;
 import com.intuit.karate.report.SuiteReports;
 import com.intuit.karate.resource.Resource;
 import com.intuit.karate.resource.ResourceUtils;
+import org.slf4j.LoggerFactory;
+
 import java.io.File;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.slf4j.LoggerFactory;
 
 import static java.util.function.Predicate.not;
 
@@ -78,6 +72,7 @@ public class Suite implements Runnable {
     public final String tagSelector;
     public final boolean dryRun;
     public final boolean debugMode;
+    public final boolean ignoreJunitNoScenariosAssertion;
     public final File workingDir;
     public final String buildDir;
     public final String reportDir;
@@ -135,6 +130,7 @@ public class Suite implements Runnable {
         if (rb.forTempUse) {
             dryRun = false;
             debugMode = false;
+            ignoreJunitNoScenariosAssertion = false;
             backupReportDir = false;
             outputHtmlReport = false;
             outputCucumberJson = false;
@@ -179,6 +175,7 @@ public class Suite implements Runnable {
             outputJunitXml = rb.outputJunitXml;
             dryRun = rb.dryRun;
             debugMode = rb.debugMode;
+            ignoreJunitNoScenariosAssertion = rb.ignoreJunitNoScenariosAssertion;
             classLoader = rb.classLoader;
             clientFactory = rb.clientFactory;
             env = rb.env;

--- a/karate-core/src/main/java/com/intuit/karate/Suite.java
+++ b/karate-core/src/main/java/com/intuit/karate/Suite.java
@@ -72,7 +72,7 @@ public class Suite implements Runnable {
     public final String tagSelector;
     public final boolean dryRun;
     public final boolean debugMode;
-    public final boolean ignoreJunitNoScenariosAssertion;
+    public final boolean failWhenNoScenariosFound;
     public final File workingDir;
     public final String buildDir;
     public final String reportDir;
@@ -130,7 +130,7 @@ public class Suite implements Runnable {
         if (rb.forTempUse) {
             dryRun = false;
             debugMode = false;
-            ignoreJunitNoScenariosAssertion = false;
+            failWhenNoScenariosFound = false;
             backupReportDir = false;
             outputHtmlReport = false;
             outputCucumberJson = false;
@@ -175,7 +175,7 @@ public class Suite implements Runnable {
             outputJunitXml = rb.outputJunitXml;
             dryRun = rb.dryRun;
             debugMode = rb.debugMode;
-            ignoreJunitNoScenariosAssertion = rb.ignoreJunitNoScenariosAssertion;
+            failWhenNoScenariosFound = rb.failWhenNoScenariosFound;
             classLoader = rb.classLoader;
             clientFactory = rb.clientFactory;
             env = rb.env;

--- a/karate-core/src/main/java/com/intuit/karate/core/MockHandler.java
+++ b/karate-core/src/main/java/com/intuit/karate/core/MockHandler.java
@@ -119,7 +119,8 @@ public class MockHandler implements ServerHandler {
         section.setIndex(-1); // TODO util for creating dummy scenario
         Scenario dummy = new Scenario(feature, section, -1);
         section.setScenario(dummy);
-        ScenarioRuntime runtime = new ScenarioRuntime(featureRuntime, dummy);        
+        ScenarioRuntime runtime = new ScenarioRuntime(featureRuntime, dummy);
+        runtime.logger.setLogOnly(true);
         runtime.engine.setVariable(PATH_MATCHES, (Function<String, Boolean>) this::pathMatches);
         runtime.engine.setVariable(PARAM_EXISTS, (Function<String, Boolean>) this::paramExists);
         runtime.engine.setVariable(PARAM_VALUE, (Function<String, String>) this::paramValue);

--- a/karate-core/src/main/java/com/intuit/karate/core/Step.java
+++ b/karate-core/src/main/java/com/intuit/karate/core/Step.java
@@ -228,7 +228,7 @@ public class Step {
     }
 
     public boolean isSetup() {
-        return scenario.isSetup();
+        return scenario !=null && scenario.isSetup();
     }
 
     @Override

--- a/karate-core/src/main/java/com/intuit/karate/http/HttpRequestBuilder.java
+++ b/karate-core/src/main/java/com/intuit/karate/http/HttpRequestBuilder.java
@@ -463,7 +463,7 @@ public class HttpRequestBuilder implements ProxyObject {
 
     public HttpRequestBuilder param(String name, List<String> values) {
         if (params == null) {
-            params = new HashMap<>();
+            params = new LinkedHashMap<>();
         }
         List<String> notNullValues = values.stream().filter(v -> v != null).collect(Collectors.toList());
         if (!notNullValues.isEmpty()) {

--- a/karate-core/src/test/java/com/intuit/karate/core/runner/no-scenario-name.feature
+++ b/karate-core/src/test/java/com/intuit/karate/core/runner/no-scenario-name.feature
@@ -10,11 +10,11 @@ Scenario:
 
 Scenario Outline:
 
-* assert <val> != 3
+* assert val != 3
 
 Examples:
-| val |
-| 1   |
-| 2   |
-| 3   |
+| val! |
+| 1    |
+| 2    |
+| 3    |
 

--- a/karate-core/src/test/java/com/intuit/karate/core/schema-read.feature
+++ b/karate-core/src/test/java/com/intuit/karate/core/schema-read.feature
@@ -1,8 +1,9 @@
 Feature:
 
-Scenario:
-* def schema = "#[] read('schema-read.json')"
-* print schema
-* match [{ foo: 'bar', items: [{ a: 1 }] }] == schema
-* configure matchEachEmptyAllowed = true
-* match [{ foo: 'bar', items: [] }] == schema
+  Scenario:
+    * def schema = "#[] read('schema-read.json')"
+    * def response = [{ foo: 'bar', items: [{ a: 1 }] }]
+    * match response == schema
+    * configure matchEachEmptyAllowed = true
+    * def response = [{ foo: 'bar', items: [] }]
+    * match response == schema

--- a/karate-gatling/src/main/java/com/intuit/karate/gatling/javaapi/KarateProtocolBuilder.java
+++ b/karate-gatling/src/main/java/com/intuit/karate/gatling/javaapi/KarateProtocolBuilder.java
@@ -46,9 +46,14 @@ public class KarateProtocolBuilder implements ProtocolBuilder {
 
     private final Map<String, Seq<MethodPause>> uriPatterns;
 
-    // Takes a JAVA Map (easier for testing) containaing SCALA MethodPauses (easier to read, save an extra Java MethodPause class and another conversion)
+    // Takes a JAVA Map (easier for testing) containaing SCALA MethodPauses (easier to read, saves an extra Java MethodPause class and another conversion)
     public KarateProtocolBuilder(java.util.Map<String, Seq<MethodPause>> uriPatterns) {
         this.uriPatterns = Converters.toScalaMap(uriPatterns);
+    }
+
+    public KarateProtocolBuilder nameResolver(BiFunction<HttpRequest, ScenarioRuntime, String> nameResolver) {
+        this.nameResolver = nameResolver;
+        return this;
     }
 
     @Override

--- a/karate-junit5/src/main/java/com/intuit/karate/junit5/Karate.java
+++ b/karate-junit5/src/main/java/com/intuit/karate/junit5/Karate.java
@@ -67,7 +67,7 @@ public class Karate extends Runner.Builder<Karate> implements Iterable<DynamicNo
             DynamicNode node = DynamicContainer.dynamicContainer(testName, featureNode);
             list.add(node);
         }
-        if (!suite.ignoreJunitNoScenariosAssertion && list.isEmpty()) {
+        if (suite.failWhenNoScenariosFound && list.isEmpty()) {
             Assertions.fail("no features or scenarios found: " + this);
         }
         return list.iterator();

--- a/karate-junit5/src/main/java/com/intuit/karate/junit5/Karate.java
+++ b/karate-junit5/src/main/java/com/intuit/karate/junit5/Karate.java
@@ -25,7 +25,6 @@ package com.intuit.karate.junit5;
 
 import com.intuit.karate.Runner;
 import com.intuit.karate.Suite;
-import com.intuit.karate.core.Feature;
 import com.intuit.karate.core.FeatureCall;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DynamicContainer;
@@ -68,7 +67,7 @@ public class Karate extends Runner.Builder<Karate> implements Iterable<DynamicNo
             DynamicNode node = DynamicContainer.dynamicContainer(testName, featureNode);
             list.add(node);
         }
-        if (list.isEmpty()) {
+        if (!suite.ignoreJunitNoScenariosAssertion && list.isEmpty()) {
             Assertions.fail("no features or scenarios found: " + this);
         }
         return list.iterator();

--- a/karate-junit5/src/test/java/karate/NoFeatureNoScenarioTest.java
+++ b/karate-junit5/src/test/java/karate/NoFeatureNoScenarioTest.java
@@ -5,18 +5,18 @@ import com.intuit.karate.junit5.Karate;
 class NoFeatureNoScenarioTest {
 
     @Karate.Test
-    Karate testValidTagWithIgnoreJunitNoScenarioAssertion() {
+    Karate testHasScenariosWithFailWhenNoScenariosFound() {
         return Karate.run("noFeatureNoScenario")
                      .tags("@smoke")
-                     .ignoreJunitNoScenariosAssertion(true)
-                     .relativeTo(getClass());
-    }
-    @Karate.Test
-    Karate testInvalidTagWithIgnoreJunitNoScenarioAssertion() {
-        return Karate.run("noFeatureNoScenario")
-                     .tags("@tagnotexist")
-                     .ignoreJunitNoScenariosAssertion(true)
+                     .failWhenNoScenariosFound(true)
                      .relativeTo(getClass());
     }
 
+    @Karate.Test
+    Karate testNoScenarios() {
+        return Karate.run("noFeatureNoScenario")
+                     .tags("@tagnotexist")
+                     .failWhenNoScenariosFound(false)
+                     .relativeTo(getClass());
+    }
 }

--- a/karate-junit5/src/test/java/karate/NoFeatureNoScenarioTest.java
+++ b/karate-junit5/src/test/java/karate/NoFeatureNoScenarioTest.java
@@ -1,0 +1,22 @@
+package karate;
+
+import com.intuit.karate.junit5.Karate;
+
+class NoFeatureNoScenarioTest {
+
+    @Karate.Test
+    Karate testValidTagWithIgnoreJunitNoScenarioAssertion() {
+        return Karate.run("noFeatureNoScenario")
+                     .tags("@smoke")
+                     .ignoreJunitNoScenariosAssertion(true)
+                     .relativeTo(getClass());
+    }
+    @Karate.Test
+    Karate testInvalidTagWithIgnoreJunitNoScenarioAssertion() {
+        return Karate.run("noFeatureNoScenario")
+                     .tags("@tagnotexist")
+                     .ignoreJunitNoScenariosAssertion(true)
+                     .relativeTo(getClass());
+    }
+
+}

--- a/karate-junit5/src/test/java/karate/noFeatureNoScenario.feature
+++ b/karate-junit5/src/test/java/karate/noFeatureNoScenario.feature
@@ -1,0 +1,5 @@
+Feature: ignoreJunitNoScenariosAssertion argument for Karate runner
+
+  @smoke
+  Scenario: smoke
+    * print 'smoke'

--- a/karate-junit5/src/test/java/karate/setup-with-dryrun.feature
+++ b/karate-junit5/src/test/java/karate/setup-with-dryrun.feature
@@ -1,5 +1,8 @@
 Feature: names
 
+Background:
+    * print 'background'
+
 @setup
 Scenario: first hello world
     * def names = [{"name": "dynamic_1"}, {"name": "dynamic_2"}]

--- a/karate-robot/src/main/java/com/intuit/karate/robot/RobotUtils.java
+++ b/karate-robot/src/main/java/com/intuit/karate/robot/RobotUtils.java
@@ -245,7 +245,7 @@ public class RobotUtils {
         key(',', KeyEvent.VK_COMMA);
         key('<', KeyEvent.VK_SHIFT, KeyEvent.VK_COMMA);
         key('.', KeyEvent.VK_PERIOD);
-        key('|', KeyEvent.VK_SHIFT, KeyEvent.VK_PERIOD);
+        key('>', KeyEvent.VK_SHIFT, KeyEvent.VK_PERIOD);
         key('/', KeyEvent.VK_SLASH);
         key('?', KeyEvent.VK_SHIFT, KeyEvent.VK_SLASH);
         //======================================================================


### PR DESCRIPTION
# PR Summary

Add Logger logOnly Mode and Enhance Test Framework Features

## Overview

This PR introduces several enhancements to the Karate framework, including a new 'logOnly' mode for the Logger class, a 'failWhenNoScenariosFound' option for test execution, and various bug fixes and improvements across multiple components.

## Change Types

| Type         | Description                            |
|--------------|----------------------------------------|
| Enhancement  | Added 'logOnly' mode to Logger class to control formatAndAppend behavior |
| Feature      | Added 'failWhenNoScenariosFound' option to Runner and Suite classes |
| Enhancement  | Modified HttpServer.Builder to support external network connections |
| Bugfix       | Fixed null check in Step class and key mapping in RobotUtils |
| Enhancement  | Changed HashMap to LinkedHashMap in HttpRequestBuilder for parameter order preservation |
| Enhancement  | Added nameResolver method to KarateProtocolBuilder |

---

## Affected Modules

| Module / File          | Change Description                       |
|------------------------|------------------------------------------|
| `src/main/java/com/intuit/karate/Logger.java` | Added 'logOnly' mode with getter/setter and conditional checks in logging methods |
| `src/main/java/com/intuit/karate/Runner.java` | Added 'failWhenNoScenariosFound' option with builder method |
| `src/main/java/com/intuit/karate/Suite.java` | Implemented 'failWhenNoScenariosFound' field and logic |
| `src/main/java/com/intuit/karate/Main.java` | Modified HttpServer.Builder to allow external connections |
| `src/main/java/com/intuit/karate/core/Step.java` | Added null check for scenario object |
| `src/main/java/com/intuit/karate/http/HttpRequestBuilder.java` | Changed HashMap to LinkedHashMap for parameter order preservation |
| `src/main/java/com/intuit/karate/robot/RobotUtils.java` | Fixed incorrect key mapping for '>' character |
| `src/main/java/com/intuit/karate/core/MockHandler.java` | Set logger to log-only mode in ScenarioRuntime |
| `src/main/java/com/intuit/karate/gatling/javaapi/KarateProtocolBuilder.java` | Added nameResolver method and fixed typo |
| `src/main/java/com/intuit/karate/junit5/Karate.java` | Added condition check for failWhenNoScenariosFound |
| `src/test/java/karate/NoFeatureNoScenarioTest.java` | Added test class for failWhenNoScenariosFound feature |

---

## Notes for Reviewers

* The 'logOnly' mode in Logger class affects all logging methods (trace, debug, info, warn) by conditionally skipping formatAndAppend
* The HttpServer.Builder change (.local(false)) exposes the server to external network connections which may have security implications
* The new 'failWhenNoScenariosFound' feature changes the default behavior of tests when no scenarios are found